### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This server is a server that installs other MCP servers for you. Install it, and
 
 ![image](https://github.com/user-attachments/assets/d082e614-b4bc-485c-a7c5-f80680348793)
 
+<a href="https://glama.ai/mcp/servers/y4xsqrbxg5"><img width="380" height="200" src="https://glama.ai/mcp/servers/y4xsqrbxg5/badge" alt="mcp-installer MCP server" /></a>
+
 ### How to install:
 
 Put this into your `claude_desktop_config.json` (either at `~/Library/Application Support/Claude` on macOS or `C:\Users\NAME\AppData\Roaming\Claude` on Windows):


### PR DESCRIPTION
This PR adds a badge for the mcp-installer server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/y4xsqrbxg5"><img width="380" height="200" src="https://glama.ai/mcp/servers/y4xsqrbxg5/badge" alt="mcp-installer MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.